### PR TITLE
add shell script to install ros_foxy docker image on WSL2 Ubuntu 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,4 +46,14 @@ RUN echo "source /opt/ros/foxy/setup.bash" >> /home/bot/.bashrc
 
 COPY ros_entrypoint.sh /bin/rossrc
 
+#Installing Gazebo 11
+RUN sudo apt install ros-foxy-gazebo-ros-pkgs -ye
+RUN sudo apt install ros-foxy-ros-core ros-foxy-geometry2 -y
+
+# Installing nvidia-docker toolkit
+sudo apt-get update 
+sudo apt-get install -y nvidia-docker2
+sudo systemctl restart docker
+
+
 ENTRYPOINT [ "rossrc" ]

--- a/join.sh
+++ b/join.sh
@@ -1,3 +1,2 @@
 #!/bin/bash
-xhost +local:root
-nvidia-docker exec -it ros_container /bin/bash --init-file './ros_entrypoint.sh'
+docker exec -it ros_container /bin/bash --init-file './ros_entrypoint.sh'

--- a/launch.sh
+++ b/launch.sh
@@ -1,13 +1,12 @@
 #!/bin/bash
-nvidia-docker run -it \
+sudo docker run -it \
     --name="ros_container" \
     --rm \
-    --env="DISPLAY=$DISPLAY" \
+    --env="DISPLAY=192.168.86.32:0" \
     --env="QT_X11_NO_MITSHM=1" \
     --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" \
     --volume=$HOME/.bash_history:/home/ros/.bash_history \
     --env="XAUTHORITY=$XAUTH" \
-    --runtime=nvidia \
     -v$PWD:/workspace \
     --expose 9090 \
     --net host \


### PR DESCRIPTION
To install ros:foxy on a windows 10 system with WSL 2 enabled and Ubuntu 20.04 installed.